### PR TITLE
Phase 1: SLO-gated canary with Argo Rollouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ flowchart TB
 
     classDef done fill:#1f6f43,stroke:#0d3,color:#fff;
     classDef plan fill:#444,stroke:#888,color:#ddd,stroke-dasharray:4 3;
-    class api,prom,loki,tempo,grafana,otelcol,argocd,sloth,scan,sign done;
-    class worker,rollout,chaos,am,remediator,rca,issue plan;
+    class api,prom,loki,tempo,grafana,otelcol,argocd,sloth,scan,sign,rollout done;
+    class worker,chaos,am,remediator,rca,issue plan;
 ```
 
 > **Legend:** solid green = built / in place today · dashed grey = on the roadmap.
@@ -116,7 +116,7 @@ sequenceDiagram
 | Phase | Focus | Key tech | Status |
 |------|-------|----------|--------|
 | **0** | Stabilize the base | OpenTelemetry, Go tests, Sloth, Trivy/cosign, Alloy | 🚧 in progress |
-| **1** | Progressive delivery | Argo Rollouts + Prometheus AnalysisTemplate | 📋 planned |
+| **1** | Progressive delivery | Argo Rollouts + Prometheus AnalysisTemplate | 🚧 implemented (pending cluster validation) |
 | **2** | Control loop + RCA copilot | Go `remediator`, Claude API | 📋 planned |
 | **3** | Story & polish | Chaos Mesh, demo recording | 📋 planned |
 
@@ -130,7 +130,13 @@ sequenceDiagram
 - ✅ **Supply chain**: image build with SBOM + provenance, cosign keyless signing, Trivy image scan ([`release.yml`](.github/workflows/release.yml))
 - ✅ Grafana LGTM Helm values (secrets externalized), ArgoCD manifests, self-hosted runner
 
-**Remaining Phase 0 polish (not blocking Phase 1):** restructure into `services/` + a `worker-service` load generator; retire the deprecated Grafana Agent in favour of Alloy.
+**Phase 1 (progressive delivery):**
+- ✅ Argo **Rollout** (canary) with a shared pod template, toggled by `rollout.enabled` ([`deploy/api-service/`](deploy/api-service/))
+- ✅ **AnalysisTemplate** querying Prometheus (5xx-ratio SLO gate) — auto-aborts and rolls back a bad canary
+- ✅ Install docs ([`argo-rollouts/`](argo-rollouts/)) and a bad-deploy auto-rollback runbook ([`demo/`](demo/))
+- ⏳ End-to-end run pending a local cluster
+
+**Remaining Phase 0 polish (not blocking):** restructure into `services/` + a `worker-service` load generator; retire the deprecated Grafana Agent in favour of Alloy.
 
 ---
 
@@ -158,7 +164,9 @@ OmniObserve/
 ├── application/        # Go api-service (OTel-instrumented)  → moves to services/ in Phase 0.2
 ├── collector/          # OTel Collector config + local docker-compose
 ├── slo/                # SLO-as-code (Sloth spec + generated Prometheus rules)
-├── deploy/api-service/ # Helm chart (Deployment, Service, ServiceMonitor)
+├── deploy/api-service/ # Helm chart (Deployment or Rollout, Service, ServiceMonitor, AnalysisTemplate)
+├── argo-rollouts/      # Argo Rollouts install + progressive-delivery docs
+├── demo/               # SLO-gated auto-rollback walkthrough + load script
 ├── LGTM/               # Grafana LGTM Helm values (secrets externalized) + local MinIO
 ├── argocd/             # ArgoCD Application manifests
 ├── .github/workflows/  # CI (ci.yml) + signed image release (release.yml)

--- a/argo-rollouts/README.md
+++ b/argo-rollouts/README.md
@@ -1,0 +1,40 @@
+# Argo Rollouts (progressive delivery)
+
+Phase 1 converts `api-service` from a Deployment to an Argo **Rollout** with a canary
+strategy, gated by an `AnalysisTemplate` that queries Prometheus. A bad version that
+breaches the error-rate SLO is **auto-aborted and rolled back**.
+
+## Install the controller (once per cluster)
+
+```bash
+kubectl create namespace argo-rollouts
+kubectl apply -n argo-rollouts \
+  -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+
+# kubectl plugin to watch/promote/abort rollouts:
+#   brew install argoproj/tap/kubectl-argo-rollouts
+# (or download from the Argo Rollouts releases page)
+```
+
+## Deploy api-service as a Rollout
+
+```bash
+helm upgrade --install api-service deploy/api-service -n monitoring \
+  --set rollout.enabled=true
+```
+
+This renders a `Rollout` + an `AnalysisTemplate` (`api-service-slo`) instead of a
+Deployment. The canary steps and SLO gate are configured under `rollout.*` in the
+chart's [values.yaml](../deploy/api-service/values.yaml):
+
+- **steps**: 25% → pause → 50% → pause → 100%
+- **analysis**: background run from step 1; aborts when the 5xx ratio query exceeds
+  `errorRatioThreshold` (0.05) more than `failureLimit` times.
+
+Watch a rollout:
+
+```bash
+kubectl argo rollouts get rollout api-service -n monitoring --watch
+```
+
+See [../demo/](../demo/) for the bad-deploy auto-rollback walkthrough.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,47 @@
+# Demo: SLO-gated auto-rollback
+
+Shows the Phase 1 payoff end to end: a canary that breaches the error-rate SLO is
+**automatically aborted and rolled back** by Argo Rollouts — no human in the loop.
+
+## Prerequisites
+
+- Local Kubernetes cluster (kind/k3d/minikube) with the LGTM stack + kube-prometheus-stack
+- Argo Rollouts controller installed ([../argo-rollouts/](../argo-rollouts/))
+- `api-service` deployed as a Rollout:
+  `helm upgrade --install api-service deploy/api-service -n monitoring --set rollout.enabled=true`
+- Prometheus scraping `job="api-service"` (the chart's ServiceMonitor does this)
+
+## Walkthrough
+
+1. **Baseline load** — keep healthy traffic flowing so the SLO metric is populated:
+
+   ```bash
+   ./demo/load.sh                 # steady 200s against /kpi/availability
+   ```
+
+2. **Trigger a canary** — any pod-template change starts a rollout. Bump the image or
+   an annotation:
+
+   ```bash
+   kubectl argo rollouts get rollout api-service -n monitoring --watch &
+   kubectl patch rollout api-service -n monitoring --type merge \
+     -p '{"spec":{"template":{"metadata":{"annotations":{"demo/rev":"bad"}}}}}'
+   ```
+
+3. **Inject the regression** — simulate a broken release by driving 5xx through the
+   service while the canary is live:
+
+   ```bash
+   ./demo/load.sh --errors        # floods /kpi/errors?error_rate=100
+   ```
+
+4. **Observe** — within ~a minute the background `AnalysisRun` sees the 5xx ratio cross
+   `errorRatioThreshold`, marks the analysis **Failed**, and Argo Rollouts **aborts**
+   the canary and shifts all traffic back to the stable ReplicaSet. The watch shows the
+   rollout `Degraded → ▮ aborted`, then healthy on the stable revision.
+
+Stop the regression load (`Ctrl-C`) and the next rollout attempt promotes cleanly.
+
+> The app is a KPI simulator, so the "bad release" is simulated via its `/kpi/errors`
+> knob. The control loop being demonstrated — SLO query → analysis fail → auto-rollback
+> — is exactly what a real regression would trigger.

--- a/demo/load.sh
+++ b/demo/load.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Load generator for the auto-rollback demo. Point at the service via a port-forward:
+#   kubectl -n monitoring port-forward svc/api-service 8080:8080
+#
+#   ./demo/load.sh            steady healthy traffic (200s)
+#   ./demo/load.sh --errors   flood 5xx to breach the error-rate SLO (500s)
+
+URL="${SERVICE_URL:-http://localhost:8080}"
+
+if [ "${1:-}" = "--errors" ]; then
+  path="/kpi/errors?error_rate=100"
+  echo "flooding 5xx -> ${URL}${path}  (Ctrl-C to stop)"
+else
+  path="/kpi/availability?success_rate=100"
+  echo "steady healthy load -> ${URL}${path}  (Ctrl-C to stop)"
+fi
+
+while true; do
+  curl -s -o /dev/null "${URL}${path}" || true
+  sleep 0.1
+done

--- a/deploy/api-service/templates/_helpers.tpl
+++ b/deploy/api-service/templates/_helpers.tpl
@@ -6,7 +6,12 @@
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -20,4 +25,49 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- define "api-service.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "api-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Pod template shared by the Deployment and the Argo Rollout (both have an identical
+spec.template). Keeping it in one place avoids the pod spec drifting between them.
+*/}}
+{{- define "api-service.podTemplate" -}}
+metadata:
+  labels:
+    {{- include "api-service.selectorLabels" . | nindent 4 }}
+spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: api-service
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      ports:
+        - name: http
+          containerPort: 8080
+      env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: {{ .Values.otel.endpoint | quote }}
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: http
+        initialDelaySeconds: 5
+        periodSeconds: 15
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: http
+        initialDelaySeconds: 3
+        periodSeconds: 10
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: [ALL]
+      resources:
+        {{- toYaml .Values.resources | nindent 8 }}
 {{- end -}}

--- a/deploy/api-service/templates/analysistemplate.yaml
+++ b/deploy/api-service/templates/analysistemplate.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rollout.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: {{ include "api-service.fullname" . }}-slo
+  labels:
+    {{- include "api-service.labels" . | nindent 4 }}
+spec:
+  metrics:
+    - name: error-ratio
+      # Mirrors the availability SLO (slo/): the canary is healthy while the 5xx
+      # ratio stays under the threshold. interval/failureLimit make the gate
+      # responsive enough to abort a bad deploy within ~a minute.
+      interval: {{ .Values.rollout.analysis.interval }}
+      failureLimit: {{ .Values.rollout.analysis.failureLimit }}
+      successCondition: result < {{ .Values.rollout.analysis.errorRatioThreshold }}
+      provider:
+        prometheus:
+          address: {{ .Values.rollout.analysis.prometheusAddress | quote }}
+          query: |
+            sum(rate(http_requests_total{job="api-service", code=~"5.."}[1m]))
+            /
+            clamp_min(sum(rate(http_requests_total{job="api-service"}[1m])), 1)
+{{- end }}

--- a/deploy/api-service/templates/deployment.yaml
+++ b/deploy/api-service/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.rollout.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,41 +11,5 @@ spec:
     matchLabels:
       {{- include "api-service.selectorLabels" . | nindent 6 }}
   template:
-    metadata:
-      labels:
-        {{- include "api-service.selectorLabels" . | nindent 8 }}
-    spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        seccompProfile:
-          type: RuntimeDefault
-      containers:
-        - name: api-service
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 8080
-          env:
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.otel.endpoint | quote }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: http
-            initialDelaySeconds: 3
-            periodSeconds: 10
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: [ALL]
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+    {{- include "api-service.podTemplate" . | nindent 4 }}
+{{- end }}

--- a/deploy/api-service/templates/rollout.yaml
+++ b/deploy/api-service/templates/rollout.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rollout.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ include "api-service.fullname" . }}
+  labels:
+    {{- include "api-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "api-service.selectorLabels" . | nindent 6 }}
+  template:
+    {{- include "api-service.podTemplate" . | nindent 4 }}
+  strategy:
+    canary:
+      # Background analysis runs from the first step; a failed SLO query aborts
+      # the rollout and rolls back to the stable ReplicaSet automatically.
+      analysis:
+        startingStep: 1
+        templates:
+          - templateName: {{ include "api-service.fullname" . }}-slo
+      steps:
+        {{- toYaml .Values.rollout.steps | nindent 8 }}
+{{- end }}

--- a/deploy/api-service/values.yaml
+++ b/deploy/api-service/values.yaml
@@ -19,6 +19,22 @@ serviceMonitor:
   enabled: true
   interval: 15s
 
+rollout:
+  # When true, render an Argo Rollout (canary) instead of a Deployment.
+  # Requires the Argo Rollouts controller + CRDs (see ../../argo-rollouts/).
+  enabled: false
+  steps:
+    - setWeight: 25
+    - pause: { duration: 30s }
+    - setWeight: 50
+    - pause: { duration: 30s }
+    - setWeight: 100
+  analysis:
+    interval: 30s
+    failureLimit: 2 # consecutive failed checks tolerated before abort
+    errorRatioThreshold: 0.05 # abort if 5xx ratio >= 5%
+    prometheusAddress: http://prometheus-operated.monitoring:9090
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
## Phase 1 — SLO-gated canary (Argo Rollouts)

The reliability payoff: a canary that breaches the error-rate SLO is **auto-aborted and rolled back**, no human in the loop.

### Changes
- **Chart refactor** — pod spec extracted into a shared `api-service.podTemplate` helper so the Deployment and Rollout never drift. `rollout.enabled` toggles between them.
- **Rollout** (`rollout.yaml`) — canary 25% → pause → 50% → pause → 100%, with **background analysis** from step 1.
- **AnalysisTemplate** (`analysistemplate.yaml`) — queries Prometheus for the 5xx ratio (`job="api-service"`, `clamp_min` denominator to avoid divide-by-zero) and fails when it crosses `errorRatioThreshold` (0.05) — which aborts the rollout.
- **fullname helper** fixed to avoid `api-service-api-service` duplication.
- **`argo-rollouts/`** install docs; **`demo/`** bad-deploy auto-rollback runbook + `load.sh`.

### Verified locally
- `helm lint` clean; both render paths checked (`rollout.enabled=false` → Deployment; `true` → Rollout + AnalysisTemplate); names and the SLO query/threshold render correctly; `load.sh` passes `bash -n`.

### Not verifiable here (no local cluster)
- The live canary → SLO-breach → auto-rollback run. The manifests and runbook are ready for a kind/k3d cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)