### PR TITLE
Phase 1 validated: bootstrap, no-data fix, version stamping, docs + RCA corpus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           sbom: true
           provenance: mode=max
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ sequenceDiagram
 
 **Remaining Phase 0 polish (not blocking):** restructure into `services/` + a `worker-service` load generator; retire the deprecated Grafana Agent in favour of Alloy.
 
+## Run it locally
+
+On a clean local cluster (Rancher Desktop / kind / k3d), from the repo root:
+
+```bash
+./bootstrap.sh          # Prometheus Operator + Argo Rollouts + api-service (canary)
+```
+
+Then follow [demo/README.md](demo/) to watch a bad canary auto-roll-back on an SLO breach.
+For rich, real telemetry, add the [OpenTelemetry Demo](workloads/otel-demo/) as a workload.
+
 ---
 
 ## Architecture decisions worth calling out
@@ -165,8 +176,10 @@ OmniObserve/
 ├── collector/          # OTel Collector config + local docker-compose
 ├── slo/                # SLO-as-code (Sloth spec + generated Prometheus rules)
 ├── deploy/api-service/ # Helm chart (Deployment or Rollout, Service, ServiceMonitor, AnalysisTemplate)
+├── bootstrap.sh        # one-command local stack (Prometheus + Argo Rollouts + api-service)
 ├── argo-rollouts/      # Argo Rollouts install + progressive-delivery docs
 ├── demo/               # SLO-gated auto-rollback walkthrough + load script
+├── workloads/otel-demo # real OTel-native app to observe (rich telemetry + fault injection)
 ├── LGTM/               # Grafana LGTM Helm values (secrets externalized) + local MinIO
 ├── argocd/             # ArgoCD Application manifests
 ├── .github/workflows/  # CI (ci.yml) + signed image release (release.yml)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ reliability loop end to end:
 
 > **chaos injection → SLO breach → alert → automatic rollback → AI-drafted RCA**
 
+📖 **New here? Read the [phase-by-phase journey](docs/) — what each piece is and *why it matters*.**
+
 ---
 
 ## The big picture (target architecture)

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -17,8 +17,9 @@ COPY docs ./docs
  RUN go install github.com/swaggo/swag/cmd/swag@latest \
  && swag init --generalInfo main.go --output ./docs
 
-# 5. Build static binary
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o go-kpi-monitor .
+# 5. Build static binary, stamping the version (passed via --build-arg VERSION=...)
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -X main.version=${VERSION}" -o go-kpi-monitor .
 
 # Runtime stage
 FROM alpine:3.21

--- a/application/main.go
+++ b/application/main.go
@@ -27,6 +27,10 @@ import (
 // Global logger
 var logger *zap.SugaredLogger
 
+// version is injected at build time via -ldflags "-X main.version=<git version>".
+// Defaults to "dev" for local `go run`/tests so every build self-identifies.
+var version = "dev"
+
 // Metrics setup
 var (
 	requestsTotal = prometheus.NewCounterVec(
@@ -192,7 +196,7 @@ func healthHandler(c *gin.Context) {
 	logger.Infow("healthz",
 		"method", c.Request.Method,
 	)
-	c.JSON(http.StatusOK, gin.H{"status": "ok", "version": "1.0.0"})
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "version": version})
 }
 
 // @Summary      Check availability

--- a/application/main_test.go
+++ b/application/main_test.go
@@ -108,7 +108,11 @@ func TestHealth_NoNilLoggerPanic(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
-	if decode(t, w)["status"] != "ok" {
+	body := decode(t, w)
+	if body["status"] != "ok" {
 		t.Fatalf("want status=ok, got %v", w.Body.String())
+	}
+	if v, _ := body["version"].(string); v == "" {
+		t.Fatal("health response missing version (ldflags injection?)")
 	}
 }

--- a/application/telemetry.go
+++ b/application/telemetry.go
@@ -30,7 +30,7 @@ func initTracer() (func(context.Context) error, error) {
 	res, err := resource.New(context.Background(),
 		resource.WithAttributes(
 			semconv.ServiceName("api-service"),
-			semconv.ServiceVersion("1.0.0"),
+			semconv.ServiceVersion(version),
 		),
 	)
 	if err != nil {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# OmniObserve — local Phase 1 bootstrap.
+# Stands up the SLO-gated auto-rollback demo on a clean LOCAL cluster
+# (Rancher Desktop / kind / k3d / minikube / docker-desktop):
+#
+#   - kube-prometheus-stack  (Prometheus Operator + Prometheus + Grafana + Alertmanager)
+#   - Argo Rollouts          (canary controller)
+#   - api-service            (canary Rollout + ServiceMonitor + SLO AnalysisTemplate)
+#
+# Re-runnable (everything is `helm upgrade --install`). Run from the repo root.
+# Override the namespace with NS=... ; skip the local-context guard with FORCE=1.
+
+NS="${NS:-monitoring}"
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+echo "==> Preflight"
+for b in kubectl helm docker; do command -v "$b" >/dev/null || { echo "ERROR: $b not found"; exit 1; }; done
+docker info >/dev/null 2>&1 || { echo "ERROR: docker daemon not running (start Rancher Desktop)"; exit 1; }
+CTX="$(kubectl config current-context)"
+echo "    context:   $CTX"
+echo "    namespace: $NS"
+case "$CTX" in
+  rancher-desktop|kind-*|k3d-*|minikube|docker-desktop) : ;;
+  *) [ "${FORCE:-0}" = "1" ] || { echo "ERROR: '$CTX' doesn't look local. Re-run with FORCE=1 if you're sure."; exit 1; } ;;
+esac
+
+echo "==> Helm repos"
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
+helm repo add argo https://argoproj.github.io/argo-helm >/dev/null 2>&1 || true
+helm repo update >/dev/null
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+echo "==> kube-prometheus-stack (this pulls several images — first run is slow)"
+helm upgrade --install kps prometheus-community/kube-prometheus-stack -n "$NS" \
+  --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+  --set prometheus.prometheusSpec.ruleSelectorNilUsesHelmValues=false \
+  --set prometheus.prometheusSpec.enableRemoteWriteReceiver=true \
+  --set prometheus.prometheusSpec.retention=2h \
+  --set prometheus.prometheusSpec.resources.requests.memory=400Mi \
+  --wait --timeout 12m
+
+echo "==> Argo Rollouts controller"
+helm upgrade --install argo-rollouts argo/argo-rollouts -n argo-rollouts --create-namespace \
+  --wait --timeout 6m
+
+echo "==> Build api-service image locally (k3s uses the docker runtime — no registry push needed)"
+docker build -t omniobserve-api-service:local "$ROOT/application"
+
+echo "==> Deploy api-service as a canary Rollout"
+helm upgrade --install api-service "$ROOT/deploy/api-service" -n "$NS" \
+  --set rollout.enabled=true \
+  --set image.repository=omniobserve-api-service \
+  --set image.tag=local \
+  --set image.pullPolicy=IfNotPresent
+
+cat <<EOF
+
+==> Done. The stack is up in namespace '$NS'.
+
+Watch the rollout:
+  kubectl argo rollouts get rollout api-service -n $NS --watch
+
+Reach the service + Grafana (separate shells):
+  kubectl -n $NS port-forward svc/api-service 8080:8080
+  kubectl -n $NS port-forward svc/kps-grafana 3000:80   # admin / prom-operator
+
+Run the auto-rollback demo: see demo/README.md
+EOF

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -46,7 +46,9 @@ helm upgrade --install argo-rollouts argo/argo-rollouts -n argo-rollouts --creat
   --wait --timeout 6m
 
 echo "==> Build api-service image locally (k3s uses the docker runtime — no registry push needed)"
-docker build -t omniobserve-api-service:local "$ROOT/application"
+VERSION="$(git -C "$ROOT" describe --tags --always --dirty 2>/dev/null || echo dev)"
+echo "    version: $VERSION"
+docker build --build-arg VERSION="$VERSION" -t omniobserve-api-service:local "$ROOT/application"
 
 echo "==> Deploy api-service as a canary Rollout"
 helm upgrade --install api-service "$ROOT/deploy/api-service" -n "$NS" \

--- a/collector/otelcol-config.yaml
+++ b/collector/otelcol-config.yaml
@@ -26,9 +26,10 @@ exporters:
     endpoint: tempo:4317
     tls:
       insecure: true
-  # Metrics -> Prometheus/Mimir remote-write.
+  # Metrics -> kube-prometheus-stack Prometheus (needs enableRemoteWriteReceiver,
+  # which bootstrap.sh sets). prometheus-operated is the Operator's headless service.
   prometheusremotewrite:
-    endpoint: http://prometheus-server/api/v1/write
+    endpoint: http://prometheus-operated:9090/api/v1/write
     tls:
       insecure: true
   # Logs -> Loki's native OTLP ingest endpoint (otlphttp appends /v1/logs).

--- a/deploy/api-service/templates/analysistemplate.yaml
+++ b/deploy/api-service/templates/analysistemplate.yaml
@@ -18,7 +18,9 @@ spec:
         prometheus:
           address: {{ .Values.rollout.analysis.prometheusAddress | quote }}
           query: |
-            sum(rate(http_requests_total{job="api-service", code=~"5.."}[1m]))
-            /
-            clamp_min(sum(rate(http_requests_total{job="api-service"}[1m])), 1)
+            (
+              sum(rate(http_requests_total{job="api-service", code=~"5.."}[1m]))
+              /
+              clamp_min(sum(rate(http_requests_total{job="api-service"}[1m])), 1)
+            ) or vector(0)
 {{- end }}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,34 @@
+# Backlog
+
+Captured ideas to tackle later — not yet implemented.
+
+## 1. Business / monetary impact (translate reliability into dollars)
+
+For a production application, document the **money** impact of each capability — what a
+hiring manager or exec actually cares about. Planned as a `docs/business-impact.md` plus
+a short "Why it matters (in dollars)" note per phase.
+
+Concrete angles to cover:
+- **Cost of downtime** — $/min for the app; progressive delivery + auto-rollback cut
+  outage minutes → $ saved.
+- **MTTR reduction** — automatic rollback + RCA copilot save expensive senior-engineer
+  hours per incident and reduce revenue lost during outages.
+- **Observability spend** — OTel + tail sampling + retention/cardinality tuning cut
+  ingest bills (real lever: Splunk→New Relic style 30% reductions).
+- **Blast-radius math** — error-budget-driven delivery avoids the cost of a *full* bad
+  deploy by exposing only a fraction of traffic.
+- **A simple calculator** — inputs (req/s, $/downtime-min, deploy frequency, % bad
+  deploys) → estimated $ avoided. Makes the value concrete and defensible.
+
+## 2. Leave room for MCP (Model Context Protocol)
+
+Future-proof the Phase 2 LLM layer so tools/data are exposed via **MCP** rather than
+hard-wired into the copilot.
+
+Concrete angles:
+- Expose the **incident corpus** (`incidents/`) and telemetry (**Prometheus / Loki /
+  Tempo / Kubernetes**) as **MCP servers**, so the RCA copilot — and any MCP client
+  (Claude Desktop/Code) — can query them as standardized tools.
+- The **remediator / RCA copilot** acts as an **MCP client** consuming those servers.
+- Design Phase 2 retrieval + tool access behind an interface an MCP server can wrap
+  later, so we don't paint ourselves into a bespoke-integration corner.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# OmniObserve — project journey
+
+OmniObserve is a **self-healing observability platform**: it detects reliability
+regressions from telemetry and remediates them automatically, with an LLM assist for
+root-cause analysis.
+
+This folder documents the project **phase by phase** — not just *what* was built, but
+*why each piece matters* for running reliable systems.
+
+| Phase | Theme | Status |
+|------|-------|--------|
+| [0 — Foundations](phase-0-foundations.md) | A trustworthy base you can observe and ship safely | ✅ done |
+| [1 — Progressive delivery](phase-1-progressive-delivery.md) | Releases that prove themselves before reaching users | ✅ implemented |
+| 2 — Auto-remediation + RCA copilot | Telemetry that triggers action, not just alerts | ⏳ next |
+
+**The thesis:** observability is only valuable if it drives **decisions and actions**.
+Each phase moves one step from *"we can see problems"* toward *"the system handles them."*

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ This folder documents the project **phase by phase** — not just *what* was bui
 |------|-------|--------|
 | [0 — Foundations](phase-0-foundations.md) | A trustworthy base you can observe and ship safely | ✅ done |
 | [1 — Progressive delivery](phase-1-progressive-delivery.md) | Releases that prove themselves before reaching users | ✅ implemented |
-| 2 — Auto-remediation + RCA copilot | Telemetry that triggers action, not just alerts | ⏳ next |
+| 2 — Auto-remediation + RCA copilot | Telemetry that triggers action, not just alerts; RCAs grounded in an [incident corpus](../incidents/) | ⏳ next |
 
 **The thesis:** observability is only valuable if it drives **decisions and actions**.
 Each phase moves one step from *"we can see problems"* toward *"the system handles them."*

--- a/docs/phase-0-foundations.md
+++ b/docs/phase-0-foundations.md
@@ -1,0 +1,23 @@
+# Phase 0 — Foundations
+
+**The problem.** You can't improve reliability you can't measure — and a pile of tools
+isn't a platform. Most "monitoring projects" stop at installing Grafana.
+
+**What this phase builds.**
+- A Go service instrumented with **OpenTelemetry** — vendor-neutral traces, metrics, logs.
+- An **OTel Collector** that fans telemetry out to the backends, so a backend can be
+  swapped without touching application code.
+- **SLOs as code** (Sloth) — the definition of "healthy" lives in version control.
+- **CI that gates quality** — tests, linting, dependency + secret scanning on every change.
+- A **signed, attested** container image — SBOM + provenance + cosign signature.
+- A **Helm chart** so the whole thing deploys repeatably.
+
+**Why it matters.**
+- **Vendor-neutral telemetry** avoids lock-in — the biggest long-term cost trap in observability.
+- **SLOs as code** makes reliability reviewable and versioned, like any other code.
+- **Supply-chain signing** answers *"can you prove what's running came from your pipeline?"* —
+  increasingly a compliance and security requirement.
+- Together these are the difference between *using* observability tools and *operating a platform*.
+
+**See it:** [`bootstrap.sh`](../bootstrap.sh), [`slo/`](../slo/), [`collector/`](../collector/),
+[`.github/workflows/`](../.github/workflows/).

--- a/docs/phase-1-progressive-delivery.md
+++ b/docs/phase-1-progressive-delivery.md
@@ -1,0 +1,25 @@
+# Phase 1 — Progressive delivery
+
+**The problem.** Most outages are self-inflicted — they arrive in a deploy. Shipping a
+new version to 100% of users at once means every bug is a full-blown outage.
+
+**What this phase builds.**
+- The app deploys as an Argo Rollouts **canary** (25% → 50% → 100%, with pauses).
+- An **AnalysisTemplate** continuously queries the error-rate SLO *during* the rollout.
+- A version that breaches the SLO is **automatically aborted and rolled back**.
+- A healthy version **promotes on its own** — no human in the loop.
+
+**Why it matters.**
+- The **SLO gate decides** whether a release ships — not a person watching dashboards,
+  not a fixed timer.
+- **Blast radius** shrinks: a bad version only ever reaches a fraction of traffic.
+- **MTTR** drops: rollback is automatic and immediate, not a 2 a.m. page.
+- This is *error-budget-driven delivery* — turning *"hope it's fine"* into *"prove it's
+  fine before exposing users."*
+
+**A real bug we caught.** The first healthy canary *failed* — with zero errors, the 5xx
+query matched no series and returned **empty**, which the gate read as a failure. The fix
+(`or vector(0)`: treat no-data as `0`) is a classic SLO-gating footgun, and exactly the
+kind of thing this project exists to surface and document.
+
+**See it:** the [demo](../demo/) — a bad canary rolls back, a good one promotes.

--- a/incidents/2026-06-04-slo-gate-no-data.md
+++ b/incidents/2026-06-04-slo-gate-no-data.md
@@ -1,0 +1,38 @@
+---
+id: INC-2026-0001
+title: Healthy canary auto-aborted by SLO gate (no-data treated as failure)
+date: 2026-06-04
+severity: SEV4
+status: resolved
+services: [api-service]
+detection: Argo Rollouts canary auto-aborted during a clean (error-free) deploy
+slo_impact: none (caught in pre-prod validation)
+tags: [slo, argo-rollouts, prometheus, promql, false-positive, gating]
+remediation:
+  - Wrap the analysis query in "( ... ) or vector(0)" so empty/no-data evaluates to 0
+---
+
+## Summary
+A canary deploy with **zero errors** was automatically aborted and rolled back. The
+SLO AnalysisTemplate's 5xx-ratio query returned an *empty* result rather than `0`, and
+Argo Rollouts scored the empty measurement as a failure.
+
+## Timeline
+- Re-triggered a clean rollout (no fault injection) to demonstrate the happy path.
+- The background AnalysisRun reported no/empty data instead of `0`.
+- After `failureLimit` checks, the rollout aborted and scaled the canary back down.
+
+## Root cause
+`sum(rate(http_requests_total{code=~"5.."}[1m]))` matches **no series** when there are
+no 5xx responses, so PromQL returns an empty vector — not `0`. The division produced an
+empty result, which the analysis provider treated as a failed measurement.
+
+## Resolution
+Wrapped the expression in `( ... ) or vector(0)` so empty / no-traffic windows evaluate
+to `0`, letting a clean canary promote while a real 5xx spike still fails the gate.
+
+## Lessons / prevention
+- In SLO gating, **empty ≠ zero** — always make "no data" an explicit, intended value.
+- Validate the **happy path** of a gate, not only its failure path.
+- A future RCA tagged `promql` + `false-positive` should check for unmatched-series /
+  empty-vector handling first.

--- a/incidents/README.md
+++ b/incidents/README.md
@@ -1,0 +1,49 @@
+# Incident RCA compendium
+
+A growing corpus of structured incident root-cause analyses. It is the **institutional
+memory** that the Phase 2 RCA copilot retrieves from, and the safety check the
+auto-remediation loop consults before acting.
+
+## Why it exists
+
+- **Grounded RCAs.** An LLM analysing an incident cold produces generic output. Given
+  similar past incidents as context, it grounds its analysis in *this system's* real
+  services, terminology, and proven fixes — higher signal, fewer hallucinations.
+- **Safer remediation.** Before auto-remediating, the loop asks "have we seen this
+  signature before, and what worked?" — precedent, not guesswork.
+- **Turns dormant data into value.** Companies already sit on years of postmortems in
+  Jira / ServiceNow / Confluence / PagerDuty. Normalised into this format, that history
+  becomes a live assistant (see *Ingesting existing data*).
+- **A flywheel.** Every incident the loop handles is written back here, so the corpus —
+  and the quality of future RCAs and remediations — compounds over time.
+
+## Format
+
+One Markdown file per incident, named `YYYY-MM-DD-slug.md`, using
+[`TEMPLATE.md`](TEMPLATE.md). The **YAML frontmatter is structured** (for filtering and
+retrieval); the body is a readable postmortem. Dual-use: humans read it, machines embed it.
+
+## How the LLM uses it (Phase 2)
+
+```
+new incident → signature (services + symptoms + metric shape)
+            → retrieve top-k similar RCAs (vector search over this corpus)
+            → feed as context to the RCA copilot (Claude)
+            → draft RCA + suggested remediation, grounded in precedent
+            → on resolution, write the new RCA back here
+```
+
+## Ingesting existing data
+
+A normaliser maps existing sources into this schema — the `remediation`, `services`,
+`tags`, and root-cause fields are what retrieval keys on:
+
+| Source | Maps to |
+|--------|---------|
+| Jira / ServiceNow incident | id, severity, timeline, services |
+| Confluence / Google Docs postmortem | summary, root cause, lessons |
+| PagerDuty / Opsgenie | detection, duration, on-call timeline |
+| Slack incident channel | timeline, actions taken |
+
+> Start small: the loop seeds the corpus with its own events. Backfill from existing
+> sources when connecting to a real org's data.

--- a/incidents/TEMPLATE.md
+++ b/incidents/TEMPLATE.md
@@ -1,0 +1,28 @@
+---
+id: INC-YYYY-NNNN
+title: <one-line description>
+date: YYYY-MM-DD
+severity: SEV1 | SEV2 | SEV3 | SEV4
+status: investigating | resolved
+services: [service-a, service-b]
+detection: <how it was detected — alert, SLO breach, user report>
+slo_impact: <error budget burned, or "none">
+tags: [<retrieval keys: e.g. prometheus, oom, deploy, false-positive>]
+remediation: # actions taken — machine-readable for the remediator/retrieval
+  - <action 1>
+---
+
+## Summary
+<2–3 sentences: what happened and the impact.>
+
+## Timeline
+- <ts> <event>
+
+## Root cause
+<the actual cause, not just the symptom.>
+
+## Resolution
+<what stopped the bleeding / fixed it.>
+
+## Lessons / prevention
+- <what to change so it doesn't recur; what a future RCA should learn from this.>

--- a/workloads/otel-demo/README.md
+++ b/workloads/otel-demo/README.md
@@ -1,0 +1,62 @@
+# Real workload: OpenTelemetry Demo
+
+Adds a **real, distributed, OTel-native** application as a system under observation,
+so the LGTM stack (and Phase 2's RCA copilot) work on real traces/metrics/logs
+instead of synthetic data. The demo also ships **built-in fault injection** (flagd
+feature flags), which makes the auto-remediation story real rather than simulated.
+
+> Do this **after** the core demo (`bootstrap.sh`) is validated. It is resource-heavy
+> (~20 pods) — give Rancher Desktop ≥ 6 GB / 4 CPU.
+
+## 1. Telemetry backends (traces, logs, collector)
+
+The core bootstrap only installs Prometheus. Add Tempo, Loki, and the collector so
+the demo's traces/logs land somewhere:
+
+```bash
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+
+# Traces
+helm upgrade --install tempo grafana/tempo -n monitoring
+
+# Logs (single-binary is fine for local)
+helm upgrade --install loki grafana/loki -n monitoring \
+  --set deploymentMode=SingleBinary --set loki.commonConfig.replication_factor=1 \
+  --set loki.storage.type=filesystem --set singleBinary.replicas=1 \
+  --set 'loki.auth_enabled=false'
+
+# Collector — fullnameOverride 'otelcol' so the Service matches our configs.
+# Supply OmniObserve's config (collector/otelcol-config.yaml) as the chart's config:
+helm upgrade --install otelcol open-telemetry/opentelemetry-collector -n monitoring \
+  --set mode=deployment --set fullnameOverride=otelcol \
+  --set image.repository=otel/opentelemetry-collector-contrib \
+  -f <(yq '{"config": load("../../collector/otelcol-config.yaml")}' 2>/dev/null \
+       || python3 -c "import yaml,sys;print(yaml.safe_dump({'config':yaml.safe_load(open('../../collector/otelcol-config.yaml'))}))")
+```
+
+If the last command's inline config trick doesn't fit your tooling, copy
+`collector/otelcol-config.yaml` under a `config:` key into a values file and pass it
+with `-f`.
+
+## 2. The demo app
+
+```bash
+helm upgrade --install otel-demo open-telemetry/opentelemetry-demo \
+  -n otel-demo --create-namespace -f values.yaml
+```
+
+`values.yaml` disables the demo's bundled observability and points every service's
+`OTEL_EXPORTER_OTLP_ENDPOINT` at our collector.
+
+## 3. Verify
+
+- Grafana → Explore → **Tempo**: traces spanning frontend → cartservice → … should appear.
+- Grafana → Explore → **Loki**: structured logs from the demo services.
+- The demo's **flagd** feature flags inject faults (e.g. `cartServiceFailure`,
+  `paymentServiceUnreachable`) — flip one and watch the error signal propagate. This is
+  the realistic regression source for the auto-remediation work in Phase 2.
+
+> Next: once this is solid, the same pattern (instrument → export OTLP to `otelcol`)
+> is how the personal **Dashboard** project plugs in as the flagship owned workload.

--- a/workloads/otel-demo/values.yaml
+++ b/workloads/otel-demo/values.yaml
@@ -1,0 +1,25 @@
+# Helm values for the OpenTelemetry Demo (open-telemetry/opentelemetry-demo),
+# wired to route ALL telemetry into OmniObserve's collector instead of the demo's
+# own bundled stack.
+#
+# Verify the keys against your chart version first:
+#   helm show values open-telemetry/opentelemetry-demo | less
+# (Subchart toggle names occasionally change between releases.)
+
+# Disable the demo's bundled observability — we use OmniObserve's collector + LGTM.
+opentelemetry-collector:
+  enabled: false
+jaeger:
+  enabled: false
+prometheus:
+  enabled: false
+grafana:
+  enabled: false
+opensearch:
+  enabled: false
+
+# Point every instrumented service at OmniObserve's collector.
+default:
+  envOverrides:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://otelcol.monitoring.svc.cluster.local:4317


### PR DESCRIPTION
## Phase 1, validated locally + project narrative

The auto-rollback demo now runs end-to-end on a real cluster (Rancher Desktop / k3s): a bad canary **auto-rolls-back**, a healthy one **auto-promotes**.

### Tooling
- **`bootstrap.sh`** — one-command local stack (kube-prometheus-stack + Argo Rollouts + api-service canary), builds the image into the docker runtime, idempotent.
- **`workloads/otel-demo/`** — run the OpenTelemetry Demo as a real observed workload (rich telemetry + fault injection).
- collector: point remote-write at `prometheus-operated`.

### Fixes from validation
- **AnalysisTemplate no-data bug** — a healthy canary (zero 5xx) made the query return *empty*, which Argo scored as a failure and aborted. Fixed with `( ... ) or vector(0)`.
- **Build version** — replaced hardcoded `1.0.0` with a git-stamped `version` via ldflags; `/healthz` + OTel `service.version` now report the real build (per-canary attribution).

### Narrative / future
- **`docs/`** — phase-by-phase journey (problem → what → why it matters), incl. Phase 0 + 1 and the no-data bug write-up.
- **`incidents/`** — seeded RCA compendium for Phase 2 RAG (corpus that grounds the LLM RCA copilot + auto-remediation precedent).
- **`docs/BACKLOG.md`** — deferred: business/$ impact docs + MCP support.

### Verified
- `go build` / `go test -race`, `helm lint` + both render paths, ldflags injection, and the live rollback/promote demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)