### PR TITLE
fix: scalar() the canary analysis query (vector type error)

### DIFF
--- a/deploy/api-service/templates/analysistemplate.yaml
+++ b/deploy/api-service/templates/analysistemplate.yaml
@@ -17,10 +17,14 @@ spec:
       provider:
         prometheus:
           address: {{ .Values.rollout.analysis.prometheusAddress | quote }}
+          # scalar() forces a Prometheus scalar type — Argo reads a vector as []float64,
+          # which breaks `result < threshold`. 'or vector(0)' keeps the no-5xx case at 0.
           query: |
-            (
-              sum(rate(http_requests_total{job="api-service", code=~"5.."}[1m]))
-              /
-              clamp_min(sum(rate(http_requests_total{job="api-service"}[1m])), 1)
-            ) or vector(0)
+            scalar(
+              (
+                sum(rate(http_requests_total{job="api-service", code=~"5.."}[1m]))
+                /
+                clamp_min(sum(rate(http_requests_total{job="api-service"}[1m])), 1)
+              ) or vector(0)
+            )
 {{- end }}

--- a/incidents/2026-06-04-analysis-vector-type-error.md
+++ b/incidents/2026-06-04-analysis-vector-type-error.md
@@ -1,0 +1,40 @@
+---
+id: INC-2026-0002
+title: Canary analysis errors with "mismatched types []float64 and float64"
+date: 2026-06-04
+severity: SEV4
+status: resolved
+services: [api-service]
+detection: Argo Rollouts AnalysisRun Phase=Error, canary aborted
+slo_impact: none (caught in pre-prod validation)
+tags: [argo-rollouts, prometheus, promql, analysis, type-error, gating, flaky]
+remediation:
+  - Wrap the analysis query in scalar() so Prometheus returns a scalar, not a vector
+---
+
+## Summary
+After fixing the no-data case ([[INC-2026-0001]]), the canary analysis still failed —
+**intermittently**. The AnalysisRun reported `Phase: Error`, message
+`invalid operation: < (mismatched types []float64 and float64)`.
+
+## Timeline
+- A clean rollout (`good3`) promoted successfully right after the no-data fix.
+- A later clean rollout (rev 4) aborted with the type-mismatch error.
+
+## Root cause
+The query returned a Prometheus **instant vector**. Argo Rollouts reads a vector
+result as `[]float64`, so `successCondition: result < 0.05` compared a slice to a
+scalar and errored. It was intermittent because Argo special-cases a *single*-element
+vector as `float64` — so when the vector had exactly one sample it worked, otherwise it
+errored.
+
+## Resolution
+Wrapped the expression in `scalar( ... )`, which makes Prometheus return a **scalar
+type**. Argo always reads a scalar as `float64`, so the comparison is stable regardless
+of element count. `or vector(0)` stays inside to keep the no-5xx case at `0` (not NaN).
+
+## Lessons / prevention
+- Argo Rollouts Prometheus `successCondition` queries should return a **scalar** — wrap
+  vector expressions in `scalar()`.
+- Intermittent gate failures are a smell for **result-type/cardinality** issues, not load.
+- A future RCA tagged `argo-rollouts` + `promql` should check the result *type* first.


### PR DESCRIPTION
Fixes the intermittent `mismatched types []float64 and float64` AnalysisRun error by wrapping the Prometheus query in `scalar()` (Argo reads a vector as `[]float64`). Logged as INC-2026-0002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)