### PR TITLE
Phase 2 step 4: RCA copilot (vendor-agnostic, corpus-grounded)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,8 +62,9 @@ helm upgrade --install api-service "$ROOT/deploy/api-service" -n "$NS" \
   --set image.tag=local \
   --set image.pullPolicy=IfNotPresent
 
-echo "==> Build + deploy the remediator (control loop: Alertmanager webhook -> action)"
-docker build --build-arg VERSION="$VERSION" -t omniobserve-remediator:local "$ROOT/remediator"
+echo "==> Build + deploy the remediator (control loop: Alertmanager webhook -> action + RCA)"
+# Root context so the incident corpus is baked in for the RCA copilot.
+docker build -f "$ROOT/remediator/Dockerfile" --build-arg VERSION="$VERSION" -t omniobserve-remediator:local "$ROOT"
 helm upgrade --install remediator "$ROOT/deploy/remediator" -n "$NS" \
   --set image.repository=omniobserve-remediator \
   --set image.tag=local \

--- a/deploy/remediator/rca-secret.example.yaml
+++ b/deploy/remediator/rca-secret.example.yaml
@@ -1,0 +1,19 @@
+# RCA copilot secrets — COPY to rca-secret.yaml (gitignored), fill in, and apply:
+#   cp deploy/remediator/rca-secret.example.yaml deploy/remediator/rca-secret.yaml
+#   # edit the values, then:
+#   kubectl -n monitoring apply -f deploy/remediator/rca-secret.yaml
+#
+# All keys are optional — omit a key and that capability stays disabled:
+#   LLM_API_KEY    enables the copilot (vendor-agnostic; pairs with rca.llm.baseURL/model)
+#   GRAFANA_TOKEN  enables the Grafana-annotation sink
+#   GITHUB_TOKEN   enables the GitHub issue + corpus-draft sinks
+apiVersion: v1
+kind: Secret
+metadata:
+  name: remediator-rca
+  namespace: monitoring
+type: Opaque
+stringData:
+  LLM_API_KEY: "REPLACE_ME"
+  GRAFANA_TOKEN: "REPLACE_ME"
+  GITHUB_TOKEN: "REPLACE_ME"

--- a/deploy/remediator/templates/deployment.yaml
+++ b/deploy/remediator/templates/deployment.yaml
@@ -42,6 +42,42 @@ spec:
               value: {{ .Values.flagd.configKey | quote }}
             - name: REMEDIATOR_COOLDOWN_SECONDS
               value: {{ .Values.cooldownSeconds | quote }}
+            {{- if .Values.rca.enabled }}
+            # RCA copilot — non-secret config from values, secrets from .Values.rca.secretName
+            # (optional: missing keys just leave the copilot/sinks disabled).
+            - name: LLM_BASE_URL
+              value: {{ .Values.rca.llm.baseURL | quote }}
+            - name: LLM_MODEL
+              value: {{ .Values.rca.llm.model | quote }}
+            - name: PROMETHEUS_URL
+              value: {{ .Values.rca.prometheusURL | quote }}
+            - name: GRAFANA_URL
+              value: {{ .Values.rca.grafanaURL | quote }}
+            - name: GITHUB_REPO
+              value: {{ .Values.rca.github.repo | quote }}
+            - name: RCA_DRAFTS_BRANCH
+              value: {{ .Values.rca.github.draftsBranch | quote }}
+            - name: CORPUS_DIR
+              value: /app/incidents
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.rca.secretName }}
+                  key: LLM_API_KEY
+                  optional: true
+            - name: GRAFANA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.rca.secretName }}
+                  key: GRAFANA_TOKEN
+                  optional: true
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.rca.secretName }}
+                  key: GITHUB_TOKEN
+                  optional: true
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/remediator/values.yaml
+++ b/deploy/remediator/values.yaml
@@ -42,6 +42,22 @@ rbac:
   # Create the ServiceAccount + Role/RoleBinding that let the remediator patch flagd.
   create: true
 
+# RCA copilot: on a remediation, draft a grounded RCA and publish it. All non-secret
+# config is here; secrets (LLM_API_KEY, GRAFANA_TOKEN, GITHUB_TOKEN) come from an existing
+# Secret named below — NOT created by this chart and NOT committed. See rca-secret.example.yaml.
+# The copilot degrades gracefully: with no LLM key it stays disabled and the loop is action-only.
+rca:
+  enabled: true
+  secretName: remediator-rca
+  llm:
+    baseURL: "" # e.g. https://generativelanguage.googleapis.com/v1beta/openai (vendor-agnostic)
+    model: "" # e.g. gemini-2.0-flash, gpt-4o, llama3.1
+  prometheusURL: "http://kps-kube-prometheus-stack-prometheus.monitoring:9090"
+  grafanaURL: "http://kps-grafana.monitoring"
+  github:
+    repo: "" # owner/name — where RCA issues + corpus drafts land
+    draftsBranch: "rca-drafts"
+
 resources:
   requests:
     cpu: 25m

--- a/docs/phase-2-auto-remediation.md
+++ b/docs/phase-2-auto-remediation.md
@@ -54,7 +54,10 @@ flagd feature flag injects a fault  ──▶  OTel Demo errors / latency climb
    idempotent, least-privilege RBAC). flagd repointed to watch the ConfigMap so a patch
    reloads live — [INC-2026-0007](../incidents/). **Validated hands-off on-cluster:**
    `productCatalogFailure` → SLO alert → remediator → flag off → heal.
-4. ⏳ The **RCA copilot**: incident-window evidence pull + vendor-agnostic LLM + corpus RAG.
+4. ✅ The **RCA copilot**: on a remediation, gather Prometheus evidence + retrieve corpus
+   precedent (tag/keyword RAG) → vendor-agnostic LLM → grounded RCA → publish to a Grafana
+   annotation, a GitHub issue, and a committed corpus draft. Degrades to action-only with
+   no LLM key. (Live drafting needs an LLM API key; see [`remediator/`](../remediator/).)
 5. ⏳ Chaos demo: one `flagd` flip drives the whole loop unattended.
 
 > Open decisions are tracked at the top of the relevant step as we reach it.

--- a/incidents/2026-06-04-1930-apiserver-cpu-starvation.md
+++ b/incidents/2026-06-04-1930-apiserver-cpu-starvation.md
@@ -6,7 +6,7 @@ occurred: 2026-06-04T19:30:00-06:00
 severity: SEV2
 status: resolved
 services: [kube-apiserver, opentelemetry-demo]
-detection: kubectl failing with "net/http: TLS handshake timeout" / "context deadline exceeded"; docker socket also down
+detection: 'kubectl failing with "net/http: TLS handshake timeout" / "context deadline exceeded"; docker socket also down'
 slo_impact: full local control-plane outage (pre-prod) — no kubectl, no scheduling
 tags: [capacity, cpu, control-plane, apiserver, resource-limits, load-generator, single-node]
 remediation:

--- a/remediator/Dockerfile
+++ b/remediator/Dockerfile
@@ -1,13 +1,15 @@
+# Build from the REPO ROOT context (docker build -f remediator/Dockerfile .) so the
+# incident corpus (incidents/) can be baked in for the RCA copilot to ground on.
 # Build stage
 FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 # Deps first for layer caching.
-COPY go.mod go.sum ./
+COPY remediator/go.mod remediator/go.sum ./
 RUN go mod download
 
-# Source (main.go, telemetry.go, webhook.go).
-COPY *.go ./
+# Remediator source (top-level *.go + internal/ packages).
+COPY remediator/ ./
 
 # Static binary, version stamped via --build-arg VERSION=...
 ARG VERSION=dev
@@ -17,10 +19,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -X main.version=${VERSION}
 FROM alpine:3.21
 WORKDIR /app
 
-# CA certs for outbound HTTPS (Kubernetes API, LLM endpoint in later steps).
+# CA certs for outbound HTTPS (Kubernetes API, LLM endpoint, GitHub).
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /app/remediator /app/
+# The incident corpus the RCA copilot retrieves precedent from (CORPUS_DIR=/app/incidents).
+COPY incidents /app/incidents
 
 EXPOSE 8080
 

--- a/remediator/README.md
+++ b/remediator/README.md
@@ -1,37 +1,58 @@
 # remediator — OmniObserve's control loop
 
-The service that turns alerts into **action**. It receives **Alertmanager** webhooks when
-an SLO burns and (in later steps) takes a bounded, auditable remediation — closing the
-loop from *"we can see the problem"* to *"the system handled it."* See
-[`docs/phase-2-auto-remediation.md`](../docs/phase-2-auto-remediation.md) for the full design.
+The service that turns alerts into **action** and **explanation**. It receives
+**Alertmanager** webhooks when an SLO burns, takes a bounded auto-remediation, and drafts
+a grounded RCA — closing the loop from *"we can see the problem"* to *"the system handled
+it, and here's why it happened."* See
+[`docs/phase-2-auto-remediation.md`](../docs/phase-2-auto-remediation.md) for the design.
 
-## Status: step 1 — observe-only
+## What it does
 
-This first cut **takes no action**. It validates the alert path end-to-end before the
-loop is given any power:
+- `POST /webhook` — parse an Alertmanager payload; log + count alerts
+  (`remediator_alerts_received_total`).
+- **Bounded action** — for a firing alert whose `remediation_flag` annotation names a flagd
+  flag, set that flag's `defaultVariant` to `off` in the flagd ConfigMap (flagd hot-reloads
+  and pushes to consumers — no restarts). Dry-run toggle, per-incident cooldown, idempotent,
+  least-privilege RBAC scoped to the one ConfigMap. Audited by `remediator_actions_total`.
+- **RCA copilot** — on a real remediation, asynchronously: gather Prometheus evidence,
+  retrieve relevant prior incidents from the baked-in corpus (`internal/corpus`), and ask a
+  **vendor-agnostic** LLM (`internal/llm`) for a structured RCA grounded in that material,
+  then publish to the configured sinks (`internal/sink`). Audited by
+  `remediator_rca_drafts_total`.
+- `GET /healthz`, `GET /metrics`; OpenTelemetry-traced as service `remediator` — the
+  platform observes its own control loop.
 
-- `POST /webhook` — parse an Alertmanager payload, log each alert, and count it
-  (`remediator_alerts_received_total{alertname,status}`).
-- `GET /healthz` — liveness + build version.
-- `GET /metrics` — Prometheus metrics.
+## Packages
 
-It is itself **OpenTelemetry-instrumented** (service `remediator`), so its decisions show
-up as traces next to the incidents it reacts to — the platform observes its own control loop.
+| Package | Role |
+|---|---|
+| `internal/llm` | OpenAI-compatible chat client — provider chosen by base URL + model + key |
+| `internal/corpus` | Loads `incidents/*.md`, retrieves precedent by tag/keyword overlap (no embeddings) |
+| `internal/evidence` | Prometheus instant queries (gRPC + HTTP RED metrics) per service |
+| `internal/rca` | The copilot: evidence + precedent + alert → grounded RCA prompt → LLM |
+| `internal/sink` | Grafana annotation, GitHub issue, GitHub corpus-draft sinks (best-effort, config-gated) |
 
-## Next steps (see the design doc)
+## Enabling the RCA copilot (needs an LLM key)
 
-2. Wire the SLO alert → Alertmanager → this webhook.
-3. First bounded action: **disable the offending feature flag** (flagd kill switch),
-   behind a dry-run flag, idempotent per `incident_key`, rate-limited.
-4. RCA copilot: pull the incident window's traces/metrics → vendor-agnostic LLM
-   ([[vendor-agnostic-llm]]) → grounded RCA → incident file + GitHub issue + Grafana annotation.
+Without an LLM key the loop is **action-only** (the copilot logs `enabled:false`). To turn
+it on, set the non-secret config in the chart and provide the secret:
+
+```bash
+# 1) non-secret: pick any OpenAI-compatible endpoint + model (vendor-agnostic)
+helm upgrade remediator deploy/remediator -n monitoring --reuse-values \
+  --set rca.llm.baseURL=https://generativelanguage.googleapis.com/v1beta/openai \
+  --set rca.llm.model=gemini-2.0-flash \
+  --set rca.github.repo=tomjga/OmniObserve
+
+# 2) secret (gitignored): cp the example, fill keys, apply
+cp deploy/remediator/rca-secret.example.yaml deploy/remediator/rca-secret.yaml
+#   edit LLM_API_KEY (+ optional GRAFANA_TOKEN / GITHUB_TOKEN), then:
+kubectl -n monitoring apply -f deploy/remediator/rca-secret.yaml
+```
 
 ## Run locally
 
 ```bash
 go test -race ./...
-go run .            # listens on :8080
-# simulate an alert:
-curl -XPOST localhost:8080/webhook -H 'content-type: application/json' \
-  -d '{"status":"firing","alerts":[{"status":"firing","labels":{"alertname":"HighErrorRate","service":"cart","severity":"critical"},"annotations":{"summary":"cart 5xx burning SLO"}}]}'
+go run .            # listens on :8080 (observe-only without a cluster)
 ```

--- a/remediator/go.mod
+++ b/remediator/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/zap v1.27.1
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -84,7 +85,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect

--- a/remediator/internal/corpus/corpus.go
+++ b/remediator/internal/corpus/corpus.go
@@ -1,0 +1,119 @@
+// Package corpus loads the incident-RCA corpus (incidents/*.md) and retrieves the most
+// relevant past incidents for a new alert. Retrieval is deliberately simple — tag,
+// service, and title-keyword overlap, no embeddings or vector DB. At this corpus size
+// that's accurate, explainable, and dependency-free, and it makes the RCA copilot's
+// grounding auditable: you can see exactly which precedents it was given.
+package corpus
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Incident is one RCA from the corpus.
+type Incident struct {
+	ID       string   `yaml:"id"`
+	Title    string   `yaml:"title"`
+	Tags     []string `yaml:"tags"`
+	Services []string `yaml:"services"`
+	Body     string   `yaml:"-"` // markdown after the frontmatter
+}
+
+var frontmatter = regexp.MustCompile(`(?s)^---\n(.*?)\n---\n?(.*)$`)
+
+// Load parses every *.md in dir (skipping TEMPLATE.md and README.md) into Incidents.
+// A file that doesn't parse is skipped, not fatal — one malformed RCA must not blind
+// the copilot to the rest of the corpus.
+func Load(dir string) ([]Incident, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []Incident
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".md") || name == "TEMPLATE.md" || name == "README.md" {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		m := frontmatter.FindSubmatch(raw)
+		if m == nil {
+			continue
+		}
+		var inc Incident
+		if err := yaml.Unmarshal(m[1], &inc); err != nil {
+			continue
+		}
+		inc.Body = strings.TrimSpace(string(m[2]))
+		if inc.ID != "" {
+			out = append(out, inc)
+		}
+	}
+	return out, nil
+}
+
+type scored struct {
+	inc   Incident
+	score int
+}
+
+// Retrieve returns up to k incidents most relevant to the query terms, scoring tag and
+// service matches highest and title-word overlap lower. Incidents with zero overlap are
+// dropped — better to give the LLM nothing than irrelevant precedent.
+func Retrieve(incidents []Incident, terms []string, k int) []Incident {
+	want := map[string]bool{}
+	for _, t := range terms {
+		if t = normalize(t); t != "" {
+			want[t] = true
+		}
+	}
+
+	var ranked []scored
+	for _, inc := range incidents {
+		s := 0
+		for _, tag := range inc.Tags {
+			if want[normalize(tag)] {
+				s += 3
+			}
+		}
+		for _, svc := range inc.Services {
+			if want[normalize(svc)] {
+				s += 3
+			}
+		}
+		for _, w := range strings.Fields(inc.Title) {
+			if want[normalize(w)] {
+				s++
+			}
+		}
+		if s > 0 {
+			ranked = append(ranked, scored{inc, s})
+		}
+	}
+
+	sort.SliceStable(ranked, func(i, j int) bool { return ranked[i].score > ranked[j].score })
+	if len(ranked) > k {
+		ranked = ranked[:k]
+	}
+	out := make([]Incident, len(ranked))
+	for i, r := range ranked {
+		out[i] = r.inc
+	}
+	return out
+}
+
+var nonword = regexp.MustCompile(`[^a-z0-9]+`)
+
+// normalize lowercases and strips punctuation so "Argo-Rollouts" and "argo rollouts"
+// match on the "argo"/"rollouts" tokens.
+func normalize(s string) string {
+	return nonword.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "")
+}

--- a/remediator/internal/corpus/corpus_test.go
+++ b/remediator/internal/corpus/corpus_test.go
@@ -1,0 +1,72 @@
+package corpus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const incA = `---
+id: INC-2026-0001
+title: Healthy canary auto-aborted by SLO gate
+tags: [slo, argo-rollouts, prometheus, false-positive]
+services: [api-service]
+---
+The no-data case evaluated to NaN.
+`
+
+const incB = `---
+id: INC-2026-0007
+title: Feature-flag remediation didn't reach services
+tags: [flagd, feature-flags, configmap, propagation]
+services: [flagd, product-catalog]
+---
+flagd served a seed-once copy.
+`
+
+func writeCorpus(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"a.md":        incA,
+		"b.md":        incB,
+		"TEMPLATE.md": "---\nid: INC-YYYY\n---\nshould be skipped",
+		"notes.txt":   "ignored",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestLoad(t *testing.T) {
+	got, err := Load(writeCorpus(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("loaded %d incidents, want 2 (TEMPLATE/.txt skipped)", len(got))
+	}
+}
+
+func TestRetrieve_RanksByOverlap(t *testing.T) {
+	incidents, _ := Load(writeCorpus(t))
+
+	// An alert about product-catalog + flagd should surface INC-0007 first.
+	got := Retrieve(incidents, []string{"product-catalog", "flagd", "feature-flags"}, 2)
+	if len(got) == 0 {
+		t.Fatal("expected at least one match")
+	}
+	if got[0].ID != "INC-2026-0007" {
+		t.Errorf("top match = %s, want INC-2026-0007", got[0].ID)
+	}
+}
+
+func TestRetrieve_DropsZeroOverlap(t *testing.T) {
+	incidents, _ := Load(writeCorpus(t))
+	got := Retrieve(incidents, []string{"kafka", "oom"}, 5)
+	if len(got) != 0 {
+		t.Errorf("expected no matches for unrelated terms, got %d", len(got))
+	}
+}

--- a/remediator/internal/evidence/prometheus.go
+++ b/remediator/internal/evidence/prometheus.go
@@ -1,0 +1,89 @@
+// Package evidence gathers quantitative signals about an incident from Prometheus, so the
+// RCA copilot reasons over real numbers (error ratio, request rate) rather than just the
+// alert text. Queries are templated on the alerting service's job label and cover both
+// gRPC (rpc_server_*) and HTTP (http_requests_total) services; only those returning data
+// are reported, so the same code works across the polyglot demo.
+package evidence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Prometheus is a thin instant-query client.
+type Prometheus struct {
+	baseURL string
+	http    *http.Client
+}
+
+func NewPrometheus(baseURL string) *Prometheus {
+	return &Prometheus{baseURL: baseURL, http: &http.Client{Timeout: 10 * time.Second}}
+}
+
+// Metric is one named evidence value.
+type Metric struct {
+	Name  string
+	Value string
+}
+
+// query templates: {svc} is replaced with the alerting service's job label.
+var queries = []struct{ name, expr string }{
+	{"gRPC error ratio (5m)", `(sum(rate(rpc_server_duration_milliseconds_count{job="{svc}",rpc_grpc_status_code!="0"}[5m]))/clamp_min(sum(rate(rpc_server_duration_milliseconds_count{job="{svc}"}[5m])),1))`},
+	{"gRPC request rate /s (5m)", `sum(rate(rpc_server_duration_milliseconds_count{job="{svc}"}[5m]))`},
+	{"HTTP 5xx ratio (5m)", `(sum(rate(http_requests_total{job="{svc}",code=~"5.."}[5m]))/clamp_min(sum(rate(http_requests_total{job="{svc}"}[5m])),1))`},
+	{"HTTP request rate /s (5m)", `sum(rate(http_requests_total{job="{svc}"}[5m]))`},
+}
+
+// Gather runs the templated queries for service and returns those that produced a value.
+// Errors on individual queries are skipped (best-effort evidence), not fatal.
+func (p *Prometheus) Gather(ctx context.Context, service string) []Metric {
+	var out []Metric
+	for _, q := range queries {
+		expr := strings.ReplaceAll(q.expr, "{svc}", service)
+		if v, ok := p.instant(ctx, expr); ok {
+			out = append(out, Metric{Name: q.name, Value: v})
+		}
+	}
+	return out
+}
+
+type queryResponse struct {
+	Data struct {
+		Result []struct {
+			Value [2]any `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+// instant runs an instant query and returns the first scalar value as a string, with ok
+// false if the query failed or returned no series.
+func (p *Prometheus) instant(ctx context.Context, expr string) (string, bool) {
+	u := p.baseURL + "/api/v1/query?query=" + url.QueryEscape(expr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", false
+	}
+	resp, err := p.http.Do(req)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return "", false
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	var parsed queryResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil || len(parsed.Data.Result) == 0 {
+		return "", false
+	}
+	if s, ok := parsed.Data.Result[0].Value[1].(string); ok {
+		return s, true
+	}
+	return fmt.Sprintf("%v", parsed.Data.Result[0].Value[1]), true
+}

--- a/remediator/internal/evidence/prometheus_test.go
+++ b/remediator/internal/evidence/prometheus_test.go
@@ -1,0 +1,52 @@
+package evidence
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGather_ReturnsOnlyQueriesWithData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expr := r.URL.Query().Get("query")
+		// Only the gRPC queries return data; HTTP queries come back empty.
+		if strings.Contains(expr, "rpc_server_duration") {
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1780000000,"0.42"]}]}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	got := NewPrometheus(srv.URL).Gather(context.Background(), "product-catalog")
+
+	if len(got) != 2 {
+		t.Fatalf("got %d metrics, want 2 (the two gRPC queries)", len(got))
+	}
+	for _, m := range got {
+		if !strings.Contains(m.Name, "gRPC") {
+			t.Errorf("unexpected metric %q (HTTP queries had no data)", m.Name)
+		}
+		if m.Value != "0.42" {
+			t.Errorf("value = %q, want 0.42", m.Value)
+		}
+	}
+}
+
+func TestGather_QuerySubstitutesService(t *testing.T) {
+	var sawJob string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Query().Get("query"), `job="cart"`) {
+			sawJob = "cart"
+		}
+		_, _ = w.Write([]byte(`{"data":{"result":[]}}`))
+	}))
+	defer srv.Close()
+
+	NewPrometheus(srv.URL).Gather(context.Background(), "cart")
+	if sawJob != "cart" {
+		t.Error("service name was not substituted into the query")
+	}
+}

--- a/remediator/internal/llm/client.go
+++ b/remediator/internal/llm/client.go
@@ -1,0 +1,100 @@
+// Package llm is a vendor-agnostic chat-completion client. It speaks the
+// OpenAI-compatible /chat/completions schema, which Gemini, OpenAI, Claude (via a proxy),
+// and local runtimes (Ollama, vLLM) all implement. The provider is chosen entirely by
+// config — base URL, model, API key — so no vendor name appears in code. See the
+// project's [[vendor-agnostic-llm]] decision.
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client targets one OpenAI-compatible endpoint. Construct it with New.
+type Client struct {
+	baseURL string // e.g. https://generativelanguage.googleapis.com/v1beta/openai
+	model   string // e.g. gemini-2.0-flash, gpt-4o, llama3.1
+	apiKey  string
+	http    *http.Client
+}
+
+// New builds a client. An empty baseURL or apiKey yields a client whose Configured()
+// is false, so callers can degrade gracefully (skip RCA) instead of erroring.
+func New(baseURL, model, apiKey string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		model:   model,
+		apiKey:  apiKey,
+		http:    &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// Configured reports whether enough is set to make a call.
+func (c *Client) Configured() bool {
+	return c.baseURL != "" && c.apiKey != "" && c.model != ""
+}
+
+// Message is one chat turn.
+type Message struct {
+	Role    string `json:"role"` // "system" | "user" | "assistant"
+	Content string `json:"content"`
+}
+
+type chatRequest struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	Temperature float64   `json:"temperature"`
+}
+
+type chatResponse struct {
+	Choices []struct {
+		Message Message `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// Complete sends the messages and returns the assistant's reply text. temperature is
+// kept low (0.2) for RCA: we want grounded, repeatable analysis, not creativity.
+func (c *Client) Complete(ctx context.Context, messages []Message) (string, error) {
+	body, err := json.Marshal(chatRequest{Model: c.model, Messages: messages, Temperature: 0.2})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("llm http %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var parsed chatResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return "", fmt.Errorf("decode llm response: %w", err)
+	}
+	if parsed.Error != nil {
+		return "", fmt.Errorf("llm error: %s", parsed.Error.Message)
+	}
+	if len(parsed.Choices) == 0 {
+		return "", fmt.Errorf("llm returned no choices")
+	}
+	return parsed.Choices[0].Message.Content, nil
+}

--- a/remediator/internal/llm/client_test.go
+++ b/remediator/internal/llm/client_test.go
@@ -1,0 +1,79 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConfigured(t *testing.T) {
+	if New("", "m", "k").Configured() {
+		t.Error("empty baseURL should be unconfigured")
+	}
+	if New("u", "m", "").Configured() {
+		t.Error("empty apiKey should be unconfigured")
+	}
+	if !New("u", "m", "k").Configured() {
+		t.Error("fully set should be configured")
+	}
+}
+
+func TestComplete_SendsRequestAndParsesReply(t *testing.T) {
+	var gotAuth, gotPath string
+	var gotBody chatRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"root cause: X"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-model", "secret")
+	out, err := c.Complete(context.Background(), []Message{{Role: "user", Content: "why?"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out != "root cause: X" {
+		t.Errorf("content = %q, want 'root cause: X'", out)
+	}
+	if gotAuth != "Bearer secret" {
+		t.Errorf("auth header = %q, want 'Bearer secret'", gotAuth)
+	}
+	if gotPath != "/chat/completions" {
+		t.Errorf("path = %q, want /chat/completions", gotPath)
+	}
+	if gotBody.Model != "test-model" || len(gotBody.Messages) != 1 {
+		t.Errorf("request body wrong: %+v", gotBody)
+	}
+}
+
+func TestComplete_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "m", "k").Complete(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected an error on HTTP 429")
+	}
+}
+
+func TestComplete_NoChoices(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL, "m", "k").Complete(context.Background(), nil); err == nil {
+		t.Fatal("expected an error when no choices are returned")
+	}
+}

--- a/remediator/internal/rca/copilot.go
+++ b/remediator/internal/rca/copilot.go
@@ -1,0 +1,112 @@
+// Package rca is the RCA copilot: given an incident, it gathers evidence from Prometheus,
+// retrieves relevant precedent from the incident corpus, and asks a vendor-agnostic LLM to
+// draft a structured root-cause analysis grounded strictly in that material. The grounding
+// is the point — this is not a chatbot, it's precedent-aware incident analysis that gets
+// sharper as the corpus grows.
+package rca
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/tomjga/OmniObserve/remediator/internal/corpus"
+	"github.com/tomjga/OmniObserve/remediator/internal/evidence"
+	"github.com/tomjga/OmniObserve/remediator/internal/llm"
+)
+
+// Incident is the context the remediator hands the copilot when an alert fires.
+type Incident struct {
+	AlertName   string
+	Service     string
+	Summary     string
+	IncidentKey string
+	Action      string // what the remediator did, e.g. "disabled flagd flag productCatalogFailure"
+	StartsAt    time.Time
+}
+
+// Copilot drafts RCAs. Construct with New.
+type Copilot struct {
+	llm       *llm.Client
+	prom      *evidence.Prometheus
+	incidents []corpus.Incident
+}
+
+func New(client *llm.Client, prom *evidence.Prometheus, incidents []corpus.Incident) *Copilot {
+	return &Copilot{llm: client, prom: prom, incidents: incidents}
+}
+
+// Enabled reports whether the copilot can draft (i.e. the LLM is configured).
+func (c *Copilot) Enabled() bool { return c.llm != nil && c.llm.Configured() }
+
+// Draft produces a markdown RCA for the incident. It is best-effort about evidence and
+// precedent (missing either just means a thinner prompt), but requires the LLM to answer.
+func (c *Copilot) Draft(ctx context.Context, inc Incident) (string, error) {
+	var metrics []evidence.Metric
+	if c.prom != nil {
+		metrics = c.prom.Gather(ctx, inc.Service)
+	}
+	precedent := corpus.Retrieve(c.incidents, terms(inc), 3)
+
+	messages := []llm.Message{
+		{Role: "system", Content: systemPrompt},
+		{Role: "user", Content: userPrompt(inc, metrics, precedent)},
+	}
+	return c.llm.Complete(ctx, messages)
+}
+
+const systemPrompt = `You are an SRE incident-analysis assistant for the OmniObserve platform.
+Write a concise root-cause analysis grounded STRICTLY in the evidence and prior incidents
+provided. Do not invent metrics, logs, or causes that are not supported by the material.
+If the evidence is thin, say so. Prefer the explanation most consistent with the cited
+prior incidents. Output markdown with exactly these sections:
+## Summary
+## Likely root cause
+## Evidence considered
+## Recommended follow-up
+## Related prior incidents (cite their IDs)`
+
+func userPrompt(inc Incident, metrics []evidence.Metric, precedent []corpus.Incident) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Incident\n")
+	fmt.Fprintf(&b, "- Alert: %s\n- Service: %s\n- Summary: %s\n", inc.AlertName, inc.Service, inc.Summary)
+	if !inc.StartsAt.IsZero() {
+		fmt.Fprintf(&b, "- Started: %s\n", inc.StartsAt.UTC().Format(time.RFC3339))
+	}
+	if inc.Action != "" {
+		fmt.Fprintf(&b, "- Automated action already taken by the remediator: %s\n", inc.Action)
+	}
+
+	b.WriteString("\n# Evidence (Prometheus)\n")
+	if len(metrics) == 0 {
+		b.WriteString("(no metrics returned for this service)\n")
+	}
+	for _, m := range metrics {
+		fmt.Fprintf(&b, "- %s: %s\n", m.Name, m.Value)
+	}
+
+	b.WriteString("\n# Prior incidents (most relevant first)\n")
+	if len(precedent) == 0 {
+		b.WriteString("(no closely related prior incidents found)\n")
+	}
+	for _, p := range precedent {
+		fmt.Fprintf(&b, "## %s — %s\nTags: %s\n%s\n\n", p.ID, p.Title, strings.Join(p.Tags, ", "), p.Body)
+	}
+	return b.String()
+}
+
+var camel = regexp.MustCompile(`[A-Z][a-z]+|[A-Z]+(?:[A-Z][a-z])|[a-z]+|[0-9]+`)
+
+// terms derives retrieval keywords from the incident: the camelCase-split alert name,
+// the service, and the summary words. This is what the corpus is searched on.
+func terms(inc Incident) []string {
+	var t []string
+	t = append(t, camel.FindAllString(inc.AlertName, -1)...)
+	t = append(t, strings.Fields(inc.Summary)...)
+	if inc.Service != "" {
+		t = append(t, inc.Service)
+	}
+	return t
+}

--- a/remediator/internal/rca/copilot_test.go
+++ b/remediator/internal/rca/copilot_test.go
@@ -1,0 +1,92 @@
+package rca
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tomjga/OmniObserve/remediator/internal/corpus"
+	"github.com/tomjga/OmniObserve/remediator/internal/evidence"
+	"github.com/tomjga/OmniObserve/remediator/internal/llm"
+)
+
+func TestTerms_SplitsCamelCase(t *testing.T) {
+	got := terms(Incident{AlertName: "ProductCatalogHighErrorRate", Service: "product-catalog"})
+	joined := strings.Join(got, " ")
+	for _, want := range []string{"Product", "Catalog", "High", "Error", "Rate", "product-catalog"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("terms %v missing %q", got, want)
+		}
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	if New(llm.New("", "", ""), nil, nil).Enabled() {
+		t.Error("unconfigured LLM should make the copilot disabled")
+	}
+	if !New(llm.New("u", "m", "k"), nil, nil).Enabled() {
+		t.Error("configured LLM should enable the copilot")
+	}
+}
+
+func TestDraft_BuildsGroundedPromptAndReturnsRCA(t *testing.T) {
+	// Mock Prometheus: return data only for gRPC queries.
+	prom := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Query().Get("query"), "rpc_server_duration") {
+			_, _ = w.Write([]byte(`{"data":{"result":[{"value":[1,"0.5"]}]}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"result":[]}}`))
+	}))
+	defer prom.Close()
+
+	// Mock LLM: capture the prompt it receives, return a canned RCA.
+	var prompt string
+	llmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var req struct {
+			Messages []llm.Message `json:"messages"`
+		}
+		_ = json.Unmarshal(raw, &req)
+		for _, m := range req.Messages {
+			prompt += m.Content + "\n"
+		}
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"## Summary\nflagd fault"}}]}`))
+	}))
+	defer llmSrv.Close()
+
+	incidents := []corpus.Incident{{
+		ID: "INC-2026-0007", Title: "Feature-flag remediation didn't reach services",
+		Tags: []string{"flagd", "product-catalog"}, Services: []string{"product-catalog"},
+		Body: "flagd served a seed-once copy.",
+	}}
+
+	cp := New(llm.New(llmSrv.URL, "m", "k"), evidence.NewPrometheus(prom.URL), incidents)
+	out, err := cp.Draft(context.Background(), Incident{
+		AlertName: "ProductCatalogHighErrorRate", Service: "product-catalog",
+		Summary: "product-catalog gRPC error ratio above 5%",
+		Action:  "disabled flagd flag productCatalogFailure",
+	})
+	if err != nil {
+		t.Fatalf("draft error: %v", err)
+	}
+	if !strings.Contains(out, "Summary") {
+		t.Errorf("RCA output missing expected content: %q", out)
+	}
+
+	// The prompt must include the evidence value and the retrieved precedent ID — proof
+	// the RCA is grounded, not free-form.
+	if !strings.Contains(prompt, "0.5") {
+		t.Error("prompt did not include the Prometheus evidence")
+	}
+	if !strings.Contains(prompt, "INC-2026-0007") {
+		t.Error("prompt did not include the retrieved prior incident")
+	}
+	if !strings.Contains(prompt, "disabled flagd flag productCatalogFailure") {
+		t.Error("prompt did not include the action the remediator took")
+	}
+}

--- a/remediator/internal/sink/sink.go
+++ b/remediator/internal/sink/sink.go
@@ -1,0 +1,164 @@
+// Package sink publishes a drafted RCA to where humans (and the corpus) will see it:
+// a Grafana annotation on the incident window, a GitHub issue for triage, and a committed
+// RCA file that grows the corpus the copilot grounds future RCAs on. Every sink is
+// config-gated (Configured) and best-effort — a missing token disables that sink, and a
+// failure on one never blocks the others or the remediation itself.
+package sink
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RCA is the drafted analysis plus the metadata the sinks need.
+type RCA struct {
+	Title    string
+	Body     string // markdown
+	Service  string
+	Slug     string // filename-safe identifier, e.g. productcataloghigherrorrate
+	StartsAt time.Time
+}
+
+func do(ctx context.Context, client *http.Client, req *http.Request) error {
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return nil
+}
+
+// Grafana posts an annotation on the incident window.
+type Grafana struct {
+	URL   string // e.g. http://kps-grafana.monitoring
+	Token string // service-account / API token
+	HTTP  *http.Client
+}
+
+func (g Grafana) Configured() bool { return g.URL != "" && g.Token != "" }
+
+func (g Grafana) Publish(ctx context.Context, r RCA) error {
+	at := r.StartsAt
+	if at.IsZero() {
+		at = time.Now()
+	}
+	body, _ := json.Marshal(map[string]any{
+		"time": at.UnixMilli(),
+		"tags": []string{"omniobserve", "rca", r.Service},
+		"text": r.Title + "\n\n" + r.Body,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.URL+"/api/annotations", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+g.Token)
+	return do(ctx, g.HTTP, req)
+}
+
+// GitHubIssue opens an issue with the RCA for human triage.
+type GitHubIssue struct {
+	Repo  string // owner/name
+	Token string
+	HTTP  *http.Client
+}
+
+func (g GitHubIssue) Configured() bool { return g.Repo != "" && g.Token != "" }
+
+func (g GitHubIssue) Publish(ctx context.Context, r RCA) error {
+	body, _ := json.Marshal(map[string]any{
+		"title":  r.Title,
+		"body":   r.Body,
+		"labels": []string{"rca", "automated"},
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.github.com/repos/"+g.Repo+"/issues", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+g.Token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	return do(ctx, g.HTTP, req)
+}
+
+// GitHubCorpus commits the RCA as a new file on a drafts branch (never directly to main),
+// so the corpus grows under human review. Path: incidents/<date>-<slug>-rca.md.
+type GitHubCorpus struct {
+	Repo   string // owner/name
+	Token  string
+	Branch string // e.g. rca-drafts
+	HTTP   *http.Client
+}
+
+func (g GitHubCorpus) Configured() bool { return g.Repo != "" && g.Token != "" && g.Branch != "" }
+
+func (g GitHubCorpus) Publish(ctx context.Context, r RCA) error {
+	at := r.StartsAt
+	if at.IsZero() {
+		at = time.Now()
+	}
+	path := fmt.Sprintf("incidents/%s-%s-rca.md", at.UTC().Format("2006-01-02-1504"), r.Slug)
+	body, _ := json.Marshal(map[string]any{
+		"message": "rca(auto): " + r.Title,
+		"content": base64.StdEncoding.EncodeToString([]byte(r.Body)),
+		"branch":  g.Branch,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		"https://api.github.com/repos/"+g.Repo+"/contents/"+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+g.Token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	return do(ctx, g.HTTP, req)
+}
+
+// Publisher fans an RCA out to all configured sinks, collecting (not short-circuiting on)
+// errors so one bad sink doesn't suppress the others.
+type Publisher struct {
+	sinks map[string]interface {
+		Configured() bool
+		Publish(context.Context, RCA) error
+	}
+}
+
+// NewPublisher registers the standard sinks; unconfigured ones are simply skipped.
+func NewPublisher(g Grafana, gi GitHubIssue, gc GitHubCorpus) *Publisher {
+	return &Publisher{sinks: map[string]interface {
+		Configured() bool
+		Publish(context.Context, RCA) error
+	}{
+		"grafana":       g,
+		"github-issue":  gi,
+		"github-corpus": gc,
+	}}
+}
+
+// Result records, per sink, whether it ran and any error.
+type Result struct {
+	Sink  string
+	Error error
+}
+
+// Publish sends to every configured sink and returns one Result per attempt.
+func (p *Publisher) Publish(ctx context.Context, r RCA) []Result {
+	var results []Result
+	for name, s := range p.sinks {
+		if !s.Configured() {
+			continue
+		}
+		results = append(results, Result{Sink: name, Error: s.Publish(ctx, r)})
+	}
+	return results
+}

--- a/remediator/internal/sink/sink_test.go
+++ b/remediator/internal/sink/sink_test.go
@@ -1,0 +1,106 @@
+package sink
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestConfigured(t *testing.T) {
+	if (Grafana{URL: "u"}).Configured() {
+		t.Error("Grafana without token should be unconfigured")
+	}
+	if !(GitHubIssue{Repo: "o/r", Token: "t"}).Configured() {
+		t.Error("GitHubIssue with repo+token should be configured")
+	}
+	if (GitHubCorpus{Repo: "o/r", Token: "t"}).Configured() {
+		t.Error("GitHubCorpus without branch should be unconfigured")
+	}
+}
+
+func TestGrafana_PostsAnnotation(t *testing.T) {
+	var gotAuth string
+	var payload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &payload)
+		if r.URL.Path != "/api/annotations" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	g := Grafana{URL: srv.URL, Token: "tok", HTTP: srv.Client()}
+	if err := g.Publish(context.Background(), RCA{Title: "T", Body: "B", Service: "svc"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+	if !strings.Contains(payload["text"].(string), "T") {
+		t.Errorf("annotation text missing title: %v", payload["text"])
+	}
+}
+
+func TestGitHubCorpus_CommitsToDraftsBranch(t *testing.T) {
+	var gotPath string
+	var payload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &payload)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	// Point the client at the test server by overriding transport via a custom client
+	// is overkill; instead assert the request shape through a RoundTripper.
+	gc := GitHubCorpus{Repo: "o/r", Token: "t", Branch: "rca-drafts", HTTP: &http.Client{
+		Transport: rewriteHost(srv.URL),
+	}}
+	if err := gc.Publish(context.Background(), RCA{Title: "T", Body: "# body", Slug: "svcfail"}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if !strings.Contains(gotPath, "/repos/o/r/contents/incidents/") || !strings.HasSuffix(gotPath, "-svcfail-rca.md") {
+		t.Errorf("unexpected path %q", gotPath)
+	}
+	if payload["branch"] != "rca-drafts" {
+		t.Errorf("branch = %v, want rca-drafts", payload["branch"])
+	}
+	if _, ok := payload["content"].(string); !ok {
+		t.Error("content (base64) missing")
+	}
+}
+
+func TestPublisher_SkipsUnconfiguredCollectsResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	p := NewPublisher(
+		Grafana{URL: srv.URL, Token: "t", HTTP: srv.Client()}, // configured
+		GitHubIssue{},  // unconfigured -> skipped
+		GitHubCorpus{}, // unconfigured -> skipped
+	)
+	results := p.Publish(context.Background(), RCA{Title: "T", Body: "B"})
+	if len(results) != 1 || results[0].Sink != "grafana" || results[0].Error != nil {
+		t.Errorf("expected only grafana to run cleanly, got %+v", results)
+	}
+}
+
+// rewriteHost sends api.github.com requests to the test server instead.
+type hostRewriter struct{ target string }
+
+func rewriteHost(target string) http.RoundTripper {
+	return hostRewriter{target: strings.TrimPrefix(target, "http://")}
+}
+
+func (h hostRewriter) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = h.target
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/remediator/main.go
+++ b/remediator/main.go
@@ -111,6 +111,7 @@ func main() {
 	logger = zapLogger.Sugar()
 
 	flagRemediator = initRemediator()
+	copilot, publisher = initCopilot()
 
 	router := gin.New()
 	router.Use(gin.Recovery())
@@ -191,6 +192,12 @@ func remediate(ctx context.Context, span trace.Span, alert Alert) {
 		attribute.String("flag", flag),
 		attribute.String("outcome", result),
 	))
+
+	// When we actually disabled a flag (once per incident — repeats hit cooldown), draft
+	// a grounded RCA in the background. Async so the LLM call never blocks the webhook.
+	if outcome == OutcomeDisabled {
+		go draftRCA(alert, "disabled flagd flag "+flag)
+	}
 }
 
 // healthHandler reports liveness and the build version (same contract as api-service).

--- a/remediator/rca.go
+++ b/remediator/rca.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/tomjga/OmniObserve/remediator/internal/corpus"
+	"github.com/tomjga/OmniObserve/remediator/internal/evidence"
+	"github.com/tomjga/OmniObserve/remediator/internal/llm"
+	"github.com/tomjga/OmniObserve/remediator/internal/rca"
+	"github.com/tomjga/OmniObserve/remediator/internal/sink"
+)
+
+// copilot drafts RCAs; publisher fans them to the configured sinks. Both are nil-safe:
+// when the LLM isn't configured the copilot is disabled and the whole RCA step is skipped.
+var (
+	copilot   *rca.Copilot
+	publisher *sink.Publisher
+)
+
+// rcaDraftsTotal is the audit metric for the copilot: did it draft, and did publishing
+// to each sink succeed?
+var rcaDraftsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "remediator_rca_drafts_total",
+		Help: "RCA copilot drafts, by outcome (drafted/error) and per-sink publish result.",
+	},
+	[]string{"result"},
+)
+
+func init() { prometheus.MustRegister(rcaDraftsTotal) }
+
+// initCopilot wires the RCA copilot from env: the vendor-agnostic LLM, the in-cluster
+// Prometheus, and the incident corpus baked into the image. Returns a disabled copilot
+// (Enabled()==false) when the LLM isn't configured, so the loop runs action-only.
+func initCopilot() (*rca.Copilot, *sink.Publisher) {
+	client := llm.New(os.Getenv("LLM_BASE_URL"), os.Getenv("LLM_MODEL"), os.Getenv("LLM_API_KEY"))
+
+	var prom *evidence.Prometheus
+	if u := os.Getenv("PROMETHEUS_URL"); u != "" {
+		prom = evidence.NewPrometheus(u)
+	}
+
+	incidents, err := corpus.Load(envStr("CORPUS_DIR", "/app/incidents"))
+	if err != nil {
+		logger.Warnw("could not load incident corpus; RCAs will be ungrounded", "error", err)
+	}
+
+	cp := rca.New(client, prom, incidents)
+	logger.Infow("rca copilot",
+		"enabled", cp.Enabled(), "corpus_size", len(incidents), "model", os.Getenv("LLM_MODEL"))
+
+	httpc := &http.Client{Timeout: 20 * time.Second}
+	pub := sink.NewPublisher(
+		sink.Grafana{URL: os.Getenv("GRAFANA_URL"), Token: os.Getenv("GRAFANA_TOKEN"), HTTP: httpc},
+		sink.GitHubIssue{Repo: os.Getenv("GITHUB_REPO"), Token: os.Getenv("GITHUB_TOKEN"), HTTP: httpc},
+		sink.GitHubCorpus{Repo: os.Getenv("GITHUB_REPO"), Token: os.Getenv("GITHUB_TOKEN"),
+			Branch: envStr("RCA_DRAFTS_BRANCH", "rca-drafts"), HTTP: httpc},
+	)
+	return cp, pub
+}
+
+var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// draftRCA runs the copilot for one incident and publishes the result. It is meant to run
+// in its own goroutine with a fresh context — the LLM call can take tens of seconds and
+// must not block the webhook response or be cancelled when it returns.
+func draftRCA(alert Alert, action string) {
+	if copilot == nil || !copilot.Enabled() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	inc := rca.Incident{
+		AlertName:   alert.alertName(),
+		Service:     alert.Labels["service"],
+		Summary:     alert.Annotations["summary"],
+		IncidentKey: alert.incidentKey(),
+		Action:      action,
+		StartsAt:    alert.StartsAt,
+	}
+
+	body, err := copilot.Draft(ctx, inc)
+	if err != nil {
+		logger.Errorw("rca draft failed", "incident_key", inc.IncidentKey, "error", err)
+		rcaDraftsTotal.WithLabelValues("error").Inc()
+		return
+	}
+	rcaDraftsTotal.WithLabelValues("drafted").Inc()
+	logger.Infow("rca drafted", "incident_key", inc.IncidentKey, "chars", len(body))
+
+	r := sink.RCA{
+		Title:    "[RCA] " + inc.AlertName + " on " + inc.Service,
+		Body:     body,
+		Service:  inc.Service,
+		Slug:     strings.Trim(slugRe.ReplaceAllString(strings.ToLower(inc.AlertName), "-"), "-"),
+		StartsAt: inc.StartsAt,
+	}
+	for _, res := range publisher.Publish(ctx, r) {
+		if res.Error != nil {
+			logger.Errorw("rca publish failed", "sink", res.Sink, "error", res.Error)
+			rcaDraftsTotal.WithLabelValues("publish_error").Inc()
+		} else {
+			logger.Infow("rca published", "sink", res.Sink, "incident_key", inc.IncidentKey)
+			rcaDraftsTotal.WithLabelValues("published").Inc()
+		}
+	}
+}


### PR DESCRIPTION
On a remediation, the remediator drafts a grounded RCA and publishes it.- internal/llm (OpenAI-compatible, vendor chosen by config), internal/corpus (tag/keyword RAG over incidents/), internal/evidence (Prometheus RED queries), internal/rca (grounded prompt), internal/sink (Grafana annotation + GitHub issue + corpus draft).- Triggered async on a real remediation; degrades to action-only without an LLM key.- Corpus baked into the image (root build context). Secrets via optional secretKeyRef.- Fix INC-0005 frontmatter (was silently skipped). All packages unit-tested with httptest/fake mocks; lint clean.